### PR TITLE
SEN-384: Make SDK generator support content types which contain dots

### DIFF
--- a/generator/apis/mapper.js
+++ b/generator/apis/mapper.js
@@ -1,5 +1,6 @@
 const { getIn } = require('../utils/data');
 const { anyToPascal } = require('../utils/string');
+const { getContentType } = require('../utils/content');
 
 module.exports = class ApiMapper {
   static map(api) {
@@ -128,7 +129,7 @@ module.exports = class ApiMapper {
     }
 
     const content = getIn(requestBody, 'content');
-    const contentType = Object.keys(content)[0];
+    const contentType = getContentType(content);
     const schema = getIn(content, `${contentType}.schema`);
     const { realType, relatedModel } = this.schemaToType(schema);
 
@@ -146,7 +147,8 @@ module.exports = class ApiMapper {
     if (!content) {
       return 'void';
     }
-    const schema = getIn(content, `${Object.keys(content)[0]}.schema`);
+    const contentType = getContentType(content);
+    const schema = getIn(content, `${contentType}.schema`);
     const { realType, relatedModel } = this.schemaToType(schema);
 
     if (relatedModel && !relatedModels.includes(relatedModel)) {

--- a/generator/utils/content.js
+++ b/generator/utils/content.js
@@ -1,0 +1,4 @@
+module.exports = {
+  getContentType: (content) =>
+    Object.keys(content)[0].replace(/[.]/g, (x) => `\\${x}`),
+};

--- a/generator/utils/data.js
+++ b/generator/utils/data.js
@@ -1,9 +1,11 @@
+const split = require('split-string');
+
 const getIn = (data, path, defaultValue) => {
   if (!data || !path) {
     return data || defaultValue;
   }
   let value = data;
-  const pathArray = path.split('.');
+  const pathArray = split(path);
   for (let pathPart of pathArray) {
     value = value[pathPart];
     if (value === undefined || value === null) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1755,6 +1755,39 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+          "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extend-shallow": "^3.0.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+              "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
+              }
+            },
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
         }
       }
     },
@@ -4503,6 +4536,39 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+          "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extend-shallow": "^3.0.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+              "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
+              }
+            },
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
         }
       }
     },
@@ -4753,14 +4819,10 @@
       "dev": true
     },
     "split-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "extend-shallow": "^3.0.0"
-      }
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-6.1.0.tgz",
+      "integrity": "sha512-9UBdnmnvx2NLLd4bMs7CEKK+wSzbujVv3ONyorkP1o8M3pVJQtXDO1cN19xD1JJs6ltOrtPrkUND0HzLSinUcA==",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "mustache": "^4.1.0",
     "node-fetch": "^2.6.1",
     "prettier": "^2.2.1",
-    "typescript": "^3.9.7"
+    "typescript": "^3.9.7",
+    "split-string": "^6.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR makes the SDK generator support content types, which contain '.' in them. This is achieved by using the `split-string` module, which allows us to skip a dot if it's escaped by a backslash. A `getContentType` utility was implemented, which does exactly that to make sure things split properly.