### PR TITLE
feat: generate sdk sources on prepare

### DIFF
--- a/generator/config-v2.js
+++ b/generator/config-v2.js
@@ -1,5 +1,5 @@
 module.exports = {
-  apiURL: 'http://localhost:5000',
+  apiURL: process.env.API_URL || 'http://localhost:5000',
   target: 'ts-node-v2',
   outputDir: 'src/v2',
 };

--- a/generator/config.js
+++ b/generator/config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  apiURL: 'http://localhost:5000',
+  apiURL: process.env.API_URL || 'http://localhost:5000',
   target: 'ts-node',
   outputDir: 'src',
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:esm": "cross-env BABEL_ENV=esm babel src --root-mode upward --extensions .ts,.tsx -d dist/esm --source-maps",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --root-mode upward --extensions .ts,.tsx -d dist/cjs --source-maps",
     "build:types": "tsc --emitDeclarationOnly --declaration --declarationDir dist/types",
-    "prepare": "npm run build",
+    "prepare": "node prepare.cjs",
     "pregenerate": "rm -rf src",
     "generate": "node ./generator/index.js"
   },

--- a/prepare.cjs
+++ b/prepare.cjs
@@ -1,0 +1,8 @@
+const { execSync } = require('child_process');
+
+const apiUrl = process.env.API_URL || process.env.PLATFORM_URL;
+if (apiUrl) {
+  execSync('npm run generate', { env: { ...process.env, API_URL: apiUrl } });
+}
+
+execSync('npm run build');


### PR DESCRIPTION
This PR implements SDK source generation on prepare. If either the `API_URL` or `PLATFORM_URL` environment variables (used by the integration-hub and merchant-center respectively) are set, the `generate` script will be executed.

This is particularly useful for improving the way we use the SDK internally. When deploying the merchant-center or integration-hub in an environment running a specific platform version, this will ensure that the SDK matches the given platform completely. This will also come in handy for when we start doing tests per ticket, where we deploy from a branch and the SDK will most likely need to be regenerated.